### PR TITLE
Requirements updated - TensorFlow 2 required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 Pillow
-h5py
-tensorflow
-Keras
+h5py>=2.10.0
 Flask
+Keras>=2.3.1
+Keras-Applications>=1.0.8
+Keras-Preprocessing>=1.1.0
+tensorflow>=2.0.0
+tensorflow-estimator>=2.0.1
+


### PR DESCRIPTION
Hi, 
what do you think about updating requirements.txt file? I tested it with clean virtual env. 
It is not so clear that by default tf2 is needed. 
Reported in: https://github.com/matsui528/sis/issues/18 and https://github.com/matsui528/sis/issues/17